### PR TITLE
Fixed Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN ANTHROPIC_API_KEY=1 SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 
 


### PR DESCRIPTION
```
diff --git a/Dockerfile b/Dockerfile
index 8df61e8..92e6f0a 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/

 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-
-
-
+RUN ANTHROPIC_API_KEY=1 SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile

 # Final stage for app image
 FROM base
```

Added the `ANTHROPIC_API_KEY=1`, otherwise the docker image was not being built